### PR TITLE
Opening the Cheat Sheet leads to UnicodeDecodeError at line 425

### DIFF
--- a/Keymaps.py
+++ b/Keymaps.py
@@ -420,7 +420,7 @@ class CheatSheetRenderer(object):
 			if sublime.platform() != 'osx':
 				hr_ = hr_ + '\n' + u'{0} - CTRL, {1} - ALT, {2} - SHIFT'.format(PRETTY_KEYS['CTRL'], PRETTY_KEYS['ALT'], PRETTY_KEYS['SHIFT']).center(LINE_SIZE) + u'\n'
 
-		return hr_.format(datetime.now().strftime('%A %d %B %Y %H:%M'),
+		return hr_.format(datetime.now().strftime('%A %d %B %Y %H:%M').decode('utf-8'),
 			u'{0} keymaps found'.format(self.keymap_counter),
 			hr=hr)
 


### PR DESCRIPTION
When I open Tools -> Keymaps -> Cheat Sheet I get a blank tab "Keymaps Cheat Sheet" and message at the console:

```
Traceback (most recent call last):
  File "./Keymaps.py", line 597, in render
    elf.renderer.render(rendered)
  File "./Keymaps.py", line 471, in render
    keymaps_view.insert(edit, keymaps_view.size(), self.header)
  File "./Keymaps.py", line 425, in header
    hr=hr)
UnicodeDecodeError: 'ascii' codec can't decode byte 0xd0 in position 0: ordinal not in range(128)
```
