### PR TITLE
fix date unicode convertion

### DIFF
--- a/Keymaps.py
+++ b/Keymaps.py
@@ -418,7 +418,7 @@ class CheatSheetRenderer(object):
 			if sublime.platform() != 'osx':
 				hr_ = hr_ + '\n' + u'{0} - CTRL, {1} - ALT, {2} - SHIFT'.format(PRETTY_KEYS['CTRL'], PRETTY_KEYS['ALT'], PRETTY_KEYS['SHIFT']).center(LINE_SIZE) + u'\n'
 
-		return hr_.format(datetime.now().strftime('%A %d %B %Y %H:%M').decode('utf-8'),
+		return hr_.format(datetime.now().strftime('%A %d %B %Y %H:%M').encode('utf-8').decode('utf-8'),
 			u'{0} keymaps found'.format(self.keymap_counter),
 			hr=hr)
 


### PR DESCRIPTION
fix #13 for sublime-3

Sublime 3dev (build 3061) uses python3.3 . In python 3.x string is already a Unicode string, there's no need to decode it.

Here is py2-3 portable hack to deal with `strftime` results.
